### PR TITLE
Add required AppKit and system imports

### DIFF
--- a/VoiceInk/Models/CustomPrompt.swift
+++ b/VoiceInk/Models/CustomPrompt.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import AppKit
 
 enum PromptIcon: String, Codable, CaseIterable {
     // Document & Text

--- a/VoiceInk/PowerMode/AppPicker.swift
+++ b/VoiceInk/PowerMode/AppPicker.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 // App Picker Sheet
 struct AppPickerSheet: View {

--- a/VoiceInk/PowerMode/PowerModeConfigView.swift
+++ b/VoiceInk/PowerMode/PowerModeConfigView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ConfigurationView: View {
     let mode: ConfigurationMode

--- a/VoiceInk/PowerMode/PowerModeView.swift
+++ b/VoiceInk/PowerMode/PowerModeView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 extension View {
     func placeholder<Content: View>(

--- a/VoiceInk/PowerMode/PowerModeViewComponents.swift
+++ b/VoiceInk/PowerMode/PowerModeViewComponents.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct VoiceInkButton: View {
     let title: String

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct APIKeyManagementView: View {
     @EnvironmentObject private var aiService: AIService

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 // Define a display mode for flexible usage
 enum LanguageDisplayMode {

--- a/VoiceInk/Views/AudioPlayerView.swift
+++ b/VoiceInk/Views/AudioPlayerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import AppKit
 
 class WaveformGenerator {
     static func generateWaveformSamples(from url: URL, sampleCount: Int = 200) async -> [Float] {

--- a/VoiceInk/Views/AudioTranscribeView.swift
+++ b/VoiceInk/Views/AudioTranscribeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 import UniformTypeIdentifiers
 import AVFoundation
+import AppKit
 
 struct AudioTranscribeView: View {
     @Environment(\.modelContext) private var modelContext

--- a/VoiceInk/Views/Common/AnimatedSaveButton.swift
+++ b/VoiceInk/Views/Common/AnimatedSaveButton.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import AppKit
 
 struct AnimatedSaveButton: View {
     let textToSave: String

--- a/VoiceInk/Views/Common/AppIconView.swift
+++ b/VoiceInk/Views/Common/AppIconView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct AppIconView: View {
     var body: some View {

--- a/VoiceInk/Views/Common/CardBackground.swift
+++ b/VoiceInk/Views/Common/CardBackground.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 // Style Constants for consistent styling across components
 struct StyleConstants {

--- a/VoiceInk/Views/Components/InfoTip.swift
+++ b/VoiceInk/Views/Components/InfoTip.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// A reusable info tip component that displays helpful information in a popover
 struct InfoTip: View {

--- a/VoiceInk/Views/ContentView.swift
+++ b/VoiceInk/Views/ContentView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 import SwiftData
 import KeyboardShortcuts
+import AppKit
+import ApplicationServices
+import CoreGraphics
 
 // ViewType enum with all cases
 enum ViewType: String, CaseIterable {

--- a/VoiceInk/Views/Dictionary/DictionarySettingsView.swift
+++ b/VoiceInk/Views/Dictionary/DictionarySettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct DictionarySettingsView: View {
     @State private var selectedSection: DictionarySection = .replacements

--- a/VoiceInk/Views/Dictionary/DictionaryView.swift
+++ b/VoiceInk/Views/Dictionary/DictionaryView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct DictionaryItem: Identifiable, Hashable, Codable {
     let id: UUID

--- a/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
+++ b/VoiceInk/Views/Dictionary/EditReplacementSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 // Edit existing word replacement entry
 struct EditReplacementSheet: View {
     @ObservedObject var manager: WordReplacementManager

--- a/VoiceInk/Views/Dictionary/WordReplacementView.swift
+++ b/VoiceInk/Views/Dictionary/WordReplacementView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 extension String: Identifiable {
     public var id: String { self }

--- a/VoiceInk/Views/EnhancementSettingsView.swift
+++ b/VoiceInk/Views/EnhancementSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import AppKit
 
 struct EnhancementSettingsView: View {
     @EnvironmentObject private var enhancementService: AIEnhancementService

--- a/VoiceInk/Views/MenuBarView.swift
+++ b/VoiceInk/Views/MenuBarView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import LaunchAtLogin
+import AppKit
 
 struct MenuBarView: View {
     @EnvironmentObject var whisperState: WhisperState

--- a/VoiceInk/Views/Metrics/MetricCard.swift
+++ b/VoiceInk/Views/Metrics/MetricCard.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct MetricCard: View {
     let title: String

--- a/VoiceInk/Views/Metrics/MetricsContent.swift
+++ b/VoiceInk/Views/Metrics/MetricsContent.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Charts
+import AppKit
 
 struct MetricsContent: View {
     let transcriptions: [Transcription]

--- a/VoiceInk/Views/Metrics/MetricsSetupView.swift
+++ b/VoiceInk/Views/Metrics/MetricsSetupView.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import KeyboardShortcuts
+import AppKit
+import ApplicationServices
+import CoreGraphics
 
 struct MetricsSetupView: View {
     @EnvironmentObject private var whisperState: WhisperState

--- a/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct PerformanceAnalysisView: View {
     @Environment(\.dismiss) private var dismiss

--- a/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
+++ b/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct TimeEfficiencyView: View {
     // MARK: - Properties

--- a/VoiceInk/Views/MetricsView.swift
+++ b/VoiceInk/Views/MetricsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import SwiftData
 import Charts
 import KeyboardShortcuts
+import AppKit
+import ApplicationServices
+import CoreGraphics
 
 struct MetricsView: View {
     @Environment(\.modelContext) private var modelContext

--- a/VoiceInk/Views/ModelSettingsView.swift
+++ b/VoiceInk/Views/ModelSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ModelSettingsView: View {
     @ObservedObject var whisperPrompt: WhisperPrompt

--- a/VoiceInk/Views/Onboarding/OnboardingPermissionsView.swift
+++ b/VoiceInk/Views/Onboarding/OnboardingPermissionsView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import AVFoundation
 import AppKit
 import KeyboardShortcuts
+import ApplicationServices
+import CoreGraphics
 
 struct OnboardingPermission: Identifiable {
     let id = UUID()

--- a/VoiceInk/Views/PermissionsView.swift
+++ b/VoiceInk/Views/PermissionsView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import AVFoundation
 import Cocoa
 import KeyboardShortcuts
+import ApplicationServices
+import CoreGraphics
 
 class PermissionManager: ObservableObject {
     @Published var audioPermissionStatus = AVCaptureDevice.authorizationStatus(for: .audio)

--- a/VoiceInk/Views/PromptEditorView.swift
+++ b/VoiceInk/Views/PromptEditorView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct PromptEditorView: View {
     enum Mode {

--- a/VoiceInk/Views/Recorder/NotchRecorderView.swift
+++ b/VoiceInk/Views/Recorder/NotchRecorderView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct NotchRecorderView: View {
     @ObservedObject var whisperState: WhisperState

--- a/VoiceInk/Views/Settings/AudioInputSettingsView.swift
+++ b/VoiceInk/Views/Settings/AudioInputSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct AudioInputSettingsView: View {
     @ObservedObject var audioDeviceManager = AudioDeviceManager.shared

--- a/VoiceInk/Views/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/TranscriptionHistoryView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import AppKit
 
 struct TranscriptionHistoryView: View {
     @Environment(\.modelContext) private var modelContext

--- a/VoiceInk/Whisper/WhisperState+LocalModelManager.swift
+++ b/VoiceInk/Whisper/WhisperState+LocalModelManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import os
 import Zip
 import SwiftUI
+import AppKit
 
 
 struct WhisperModel: Identifiable {


### PR DESCRIPTION
## Summary
- add AppKit imports to SwiftUI views and models that reference macOS UI APIs so they compile
- import ApplicationServices/CoreGraphics in views that call accessibility and screen capture functions

## Testing
- not run (macOS-only project)

------
https://chatgpt.com/codex/tasks/task_e_68c9dce9e9648328b88b8e1ea5c7bfff